### PR TITLE
Fix typo in message.

### DIFF
--- a/resources/lang/en/validationRules.php
+++ b/resources/lang/en/validationRules.php
@@ -3,5 +3,5 @@
 return [
     'authorized' => 'You are not authorized to use this value.',
     'enum' => 'This is not a valid value.',
-    'model_ids' => 'Some of the given ids do not extist',
+    'model_ids' => 'Some of the given ids do not exist',
 ];


### PR DESCRIPTION
There's a typo in one of the validation error messages. This fixes it.