### PR TITLE
Add NewPassword validation rule.

### DIFF
--- a/resources/lang/en/validationRules.php
+++ b/resources/lang/en/validationRules.php
@@ -4,4 +4,5 @@ return [
     'authorized' => 'You are not authorized to use this value.',
     'enum' => 'This is not a valid value.',
     'model_ids' => 'Some of the given ids do not extist',
+    'new_password' => 'You cannot reuse the same password as before.',
 ];

--- a/src/Rules/NewPassword.php
+++ b/src/Rules/NewPassword.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace Spatie\ValidationRules\Rules;
+
+use Illuminate\Support\Facades\Hash;
+use Illuminate\Contracts\Validation\Rule;
+use Illuminate\Contracts\Auth\Authenticatable;
+
+final class NewPassword implements Rule
+{
+    private $user;
+
+    public function __construct(Authenticatable $user = null)
+    {
+        $this->user = $user;
+    }
+
+    /**
+     * Determine if the validation rule passes.
+     *
+     * @param  string  $attribute
+     * @param  mixed  $value
+     * @return bool
+     */
+    public function passes($attribute, $value)
+    {
+        if (! $this->user) {
+            return true;
+        }
+
+        return ! Hash::check($value, $this->user->getAuthPassword());
+    }
+
+    /**
+     * Get the validation error message.
+     *
+     * @return string
+     */
+    public function message()
+    {
+        return __('validationRules.new_password');
+    }
+}

--- a/tests/Rules/NewPasswordTest.php
+++ b/tests/Rules/NewPasswordTest.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace Spatie\ValidationRules\Tests\Rules;
+
+use Spatie\ValidationRules\Tests\TestCase;
+use Spatie\ValidationRules\Rules\NewPassword;
+use Illuminate\Contracts\Auth\Authenticatable;
+
+class NewPasswordTest extends TestCase
+{
+    /** @test */
+    public function it_will_return_true_if_new_password_used()
+    {
+        $rule = new NewPassword($this->mock_user());
+
+        $this->assertTrue($rule->passes('attribute', 'new_secret'));
+    }
+
+    private function mock_user(): Authenticatable
+    {
+        $mock = $this->getMockForAbstractClass(Authenticatable::class);
+
+        $mock->expects($this->once())
+            ->method('getAuthPassword')
+            ->willReturn('$2y$10$TKh8H1.PfQx37YgCzwiKb.KjNyWgaHb9cbcoQgdIVFlYg7B77UdFm'); // secret
+
+        return $mock;
+    }
+
+    /** @test */
+    public function it_will_return_false_if_old_password_used()
+    {
+        $rule = new NewPassword($this->mock_user());
+
+        $this->assertFalse($rule->passes('attribute', 'secret'));
+    }
+
+    /** @test */
+    public function it_will_return_true_if_no_user_is_used()
+    {
+        $rule = new NewPassword;
+
+        $this->assertTrue($rule->passes('attribute', 'secret'));
+    }
+}


### PR DESCRIPTION
This validation is to fail users who try to change their password to the same thing as before.