### PR TITLE
Add RFC1918 validation.

### DIFF
--- a/resources/lang/en/validationRules.php
+++ b/resources/lang/en/validationRules.php
@@ -4,4 +4,5 @@ return [
     'authorized' => 'You are not authorized to use this value.',
     'enum' => 'This is not a valid value.',
     'model_ids' => 'Some of the given ids do not extist',
+    'rfc1918' => 'Address overlaps with an RFC1918 private address.',
 ];

--- a/src/Rules/Rfc1918.php
+++ b/src/Rules/Rfc1918.php
@@ -1,0 +1,87 @@
+<?php
+
+namespace Spatie\ValidationRules\Rules;
+
+use Illuminate\Contracts\Validation\Rule;
+
+/**
+ * Class Rfc1918.
+ *
+ * Validates that the value is an IP address and does not overlap with one of the RFC1918 non-routable ranges.
+ */
+final class Rfc1918 implements Rule
+{
+    const RFC1918_RANGES = [
+        '10.0.0.0/8',
+        '172.16.0.0/21',
+        '192.168.0.0/16',
+    ];
+
+    /**
+     * Determine if the validation rule passes.
+     *
+     * @param  string  $attribute
+     * @param  mixed  $value
+     * @return bool
+     */
+    public function passes($attribute, $value)
+    {
+        $parts = explode('/', $value);
+
+        if (! filter_var($parts[0], FILTER_VALIDATE_IP)) {
+            return false;
+        }
+
+        $ip = inet_pton($parts[0]);
+
+        $range = $this->calculateRange($ip, count($parts) > 1 ? $parts[1] : 32);
+
+        foreach (static::RFC1918_RANGES as $rfc1918Range) {
+            list($privateIp, $privateMask) = explode('/', $rfc1918Range);
+            $privateRange = $this->calculateRange(inet_pton($privateIp), $privateMask);
+
+            if ($range[1] >= $privateRange[0] && $range[0] <= $privateRange[1]) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /**
+     * @param string $address Packed representation of the address used to define the range.
+     * @param int $mask
+     * @return string[] Packed representations of the starting and ending addresses in this range.
+     */
+    private function calculateRange(string $address, int $mask): array
+    {
+        // Index of returned array starts at 1, because `unpack` is weird.
+        $words = unpack('n*', $address);
+
+        $start = [];
+        $end = [];
+
+        for ($i = 0; $i < count($words); $i++) {
+            $shift = min(max($mask - 16 * $i, 0), 16);
+            $wordMask = ~(0xffff >> $shift) & 0xffff;
+
+            $start[$i] = $words[$i + 1] & $wordMask;
+            $end[$i] = $words[$i + 1] | ~$wordMask;
+        }
+
+        return [
+            pack('n*', ...$start),
+            pack('n*', ...$end),
+        ];
+    }
+
+    /**
+     * Get the validation error message.
+     *
+     * @return string
+     */
+    public function message()
+    {
+        return __('validationRules.rfc1918');
+    }
+}

--- a/tests/Rules/Rfc1918Test.php
+++ b/tests/Rules/Rfc1918Test.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Spatie\ValidationRules\Tests\Rules;
+
+use Spatie\ValidationRules\Rules\Rfc1918;
+use Spatie\ValidationRules\Tests\TestCase;
+
+class Rfc1918Test extends TestCase
+{
+    /** @test */
+    public function it_will_return_true_for_a_public_address_without_a_mask()
+    {
+        $rule = new Rfc1918;
+
+        $this->assertTrue($rule->passes('attribute', '52.25.12.78'));
+    }
+
+    /** @test */
+    public function it_will_return_true_for_a_public_address_with_a_mask()
+    {
+        $rule = new Rfc1918;
+
+        $this->assertTrue($rule->passes('attribute', '52.25.12.78/24'));
+    }
+
+    /** @test */
+    public function it_will_return_false_for_a_private_address()
+    {
+        $rule = new Rfc1918;
+
+        $this->assertFalse($rule->passes('attribute', '192.168.0.1'));
+    }
+
+    /** @test */
+    public function it_will_return_false_for_a_non_address()
+    {
+        $rule = new Rfc1918;
+
+        $this->assertFalse($rule->passes('attribute', 'fail'));
+    }
+}


### PR DESCRIPTION
To validate IPv4 addresses that are publicly routable and not part of a private range.