### PR TITLE
Fix nested attributes validation

### DIFF
--- a/src/Rules/Delimited.php
+++ b/src/Rules/Delimited.php
@@ -2,6 +2,7 @@
 
 namespace Spatie\ValidationRules\Rules;
 
+use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
 use Illuminate\Contracts\Validation\Rule;
 use Illuminate\Support\Facades\Validator;
@@ -143,7 +144,7 @@ class Delimited implements Rule
 
     protected function validate(string $attribute, string $item): array
     {
-        $attribute = Str::afterLast($attribute, '.');
+        $attribute = Arr::last(explode('.', $attribute));
 
         $validator = Validator::make([$attribute => $item], [$attribute => $this->rule]);
 

--- a/src/Rules/Delimited.php
+++ b/src/Rules/Delimited.php
@@ -143,7 +143,7 @@ class Delimited implements Rule
 
     protected function validate(string $attribute, string $item): array
     {
-        $attribute = Str::after($attribute, '.');
+        $attribute = Str::afterLast($attribute, '.');
 
         $validator = Validator::make([$attribute => $item], [$attribute => $this->rule]);
 

--- a/tests/Rules/DelimitedTest.php
+++ b/tests/Rules/DelimitedTest.php
@@ -126,6 +126,13 @@ class DelimitedTest extends TestCase
         $this->assertTrue($rule->min(2)->passes('attribute', '0, 1'));
     }
 
+    /** @test */
+    public function it_can_validate_nested_attributes_properly()
+    {
+        $rule = new Delimited('email');
+        $this->assertFalse($rule->passes('a.0.b', 'invalid email'));
+    }
+
     protected function assertRulePasses(string $value)
     {
         $this->assertTrue($this->rulePasses($value));


### PR DESCRIPTION
It always passes when validating nested attributes, even with invalid data.