### PR TITLE
fix translation issue: wrong variable names

### DIFF
--- a/src/Rules/Delimited.php
+++ b/src/Rules/Delimited.php
@@ -89,7 +89,7 @@ class Delimited implements Rule
         if (! is_null($this->minimum)) {
             if ($items->count() < $this->minimum) {
                 $this->message = __('validationRules::messages.delimited.min', [
-                    'minimum' => $this->minimum,
+                    'min' => $this->minimum,
                     'actual' => $items->count(),
                     'item' => Str::plural($this->validationMessageWord, $items->count()),
                 ]);
@@ -101,7 +101,7 @@ class Delimited implements Rule
         if (! is_null($this->maximum)) {
             if ($items->count() > $this->maximum) {
                 $this->message = __('validationRules::messages.delimited.max', [
-                    'maximum' => $this->maximum,
+                    'max' => $this->maximum,
                     'actual' => $items->count(),
                     'item' => Str::plural($this->validationMessageWord, $items->count()),
                 ]);


### PR DESCRIPTION
fix translation issue: wrong variable names for max and min