### PR TITLE
Adds the ability to specify an auth guard, and uses route name resolution for models

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,15 @@ public function rules()
 }
 ```
 
+Optionally, you can provide an authentication guard as the third parameter.
+
+```php
+new Authorized('edit', TestModel::class, 'guard-name')
+```
+
+#### Model resolution
+If you have implemented the `getRouteKeyName` method in your model, it will be used to resolve the model instance. For further information see [Customizing The Default Key Name](https://laravel.com/docs/7.x/routing)
+
 ### `CountryCode`
 
 Determine if the field under validation is a valid ISO3166 country code.

--- a/src/Rules/Authorized.php
+++ b/src/Rules/Authorized.php
@@ -39,7 +39,7 @@ class Authorized implements Rule
             return false;
         }
 
-        if (! $model = $this->className::find($value)) {
+        if (! $model = app($this->className)->resolveRouteBinding($value)) {
             return false;
         }
 

--- a/src/Rules/Authorized.php
+++ b/src/Rules/Authorized.php
@@ -19,18 +19,23 @@ class Authorized implements Rule
     /** @var string */
     protected $attribute;
 
-    public function __construct(string $ability, string $className)
+    /**
+     * @var string
+     */
+    protected $guard;
+
+    public function __construct(string $ability, string $className, string $guard = null)
     {
         $this->ability = $ability;
-
         $this->className = $className;
+        $this->guard = $guard;
     }
 
     public function passes($attribute, $value): bool
     {
         $this->attribute = $attribute;
 
-        if (! $user = Auth::user()) {
+        if (! $user = Auth::guard($this->guard)->user()) {
             return false;
         }
 

--- a/src/Rules/Authorized.php
+++ b/src/Rules/Authorized.php
@@ -19,9 +19,7 @@ class Authorized implements Rule
     /** @var string */
     protected $attribute;
 
-    /**
-     * @var string
-     */
+    /**@var string */
     protected $guard;
 
     public function __construct(string $ability, string $className, string $guard = null)

--- a/tests/Rules/AuthorizedTest.php
+++ b/tests/Rules/AuthorizedTest.php
@@ -90,4 +90,36 @@ class AuthorizedTest extends TestCase
 
         $this->assertEquals('name_field edit and TestModel', $rule->message());
     }
+
+    /** @test */
+    public function it_will_pass_if_alternate_auth_guard_is_specified()
+    {
+        $rule = new Authorized('edit', TestModel::class, 'alternate');
+
+        $user = factory(User::class)->create(['id' => 1]);
+        TestModel::create([
+            'id' => 1,
+            'user_id' => 1,
+        ]);
+
+        $this->actingAs($user, 'alternate');
+
+        $this->assertTrue($rule->passes('attribute', '1'));
+    }
+
+    /** @test */
+    public function it_will_return_false_if_auth_guard_is_incorrect()
+    {
+        $rule = new Authorized('edit', TestModel::class, 'web');
+
+        $user = factory(User::class)->create(['id' => 1]);
+        TestModel::create([
+            'id' => 1,
+            'user_id' => 1,
+        ]);
+
+        $this->actingAs($user, 'alternate');
+
+        $this->assertFalse($rule->passes('attribute', '1'));
+    }
 }

--- a/tests/Rules/AuthorizedTest.php
+++ b/tests/Rules/AuthorizedTest.php
@@ -8,7 +8,9 @@ use Illuminate\Support\Facades\Lang;
 use Spatie\ValidationRules\Rules\Authorized;
 use Spatie\ValidationRules\Tests\TestCase;
 use Spatie\ValidationRules\Tests\TestClasses\Models\TestModel;
+use Spatie\ValidationRules\Tests\TestClasses\Models\TestRouteKeyModel;
 use Spatie\ValidationRules\Tests\TestClasses\Policies\TestModelPolicy;
+use Spatie\ValidationRules\Tests\TestClasses\Policies\TestRouteKeyModelPolicy;
 
 class AuthorizedTest extends TestCase
 {
@@ -17,6 +19,7 @@ class AuthorizedTest extends TestCase
         parent::setUp();
 
         Gate::policy(TestModel::class, TestModelPolicy::class);
+        Gate::policy(TestRouteKeyModel::class, TestRouteKeyModelPolicy::class);
     }
 
     /** @test */
@@ -89,6 +92,23 @@ class AuthorizedTest extends TestCase
         $rule->passes('name_field', 'John Doe');
 
         $this->assertEquals('name_field edit and TestModel', $rule->message());
+    }
+
+    /** @test */
+    public function it_will_pass_when_using_alternate_route_key_name()
+    {
+        $rule = new Authorized('edit', TestRouteKeyModel::class);
+
+        $user = factory(User::class)->create(['id' => 1]);
+        TestRouteKeyModel::create([
+            'id' => 1,
+            'name' => 'abc123',
+            'user_id' => 1,
+        ]);
+
+        $this->actingAs($user);
+
+        $this->assertTrue($rule->passes('attribute', 'abc123'));
     }
 
     /** @test */

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -15,6 +15,7 @@ abstract class TestCase extends Orchestra
         parent::setUp();
 
         $this->setUpDatabase();
+        $this->setUpGuard();
 
         $this->app->make(EloquentFactory::class)->load(__DIR__.'/factories');
     }
@@ -43,5 +44,15 @@ abstract class TestCase extends Orchestra
             $table->unsignedInteger('user_id');
             $table->timestamps();
         });
+    }
+
+    protected function setUpGuard()
+    {
+        config([
+            'auth.guards.alternate' => [
+                'driver' => 'session',
+                'provider' => 'users',
+            ],
+        ]);
     }
 }

--- a/tests/TestClasses/Models/TestRouteKeyModel.php
+++ b/tests/TestClasses/Models/TestRouteKeyModel.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Spatie\ValidationRules\Tests\TestClasses\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Foundation\Auth\User;
+
+class TestRouteKeyModel extends Model
+{
+    protected $guarded = [];
+    protected $table = 'test_models';
+
+    public function getRouteKeyName()
+    {
+        return 'name';
+    }
+
+    public function user(): BelongsTo
+    {
+        return $this->belongsTo(User::class);
+    }
+}

--- a/tests/TestClasses/Policies/TestRouteKeyModelPolicy.php
+++ b/tests/TestClasses/Policies/TestRouteKeyModelPolicy.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Spatie\ValidationRules\Tests\TestClasses\Policies;
+
+use Illuminate\Auth\Access\HandlesAuthorization;
+use Illuminate\Foundation\Auth\User;
+use Spatie\ValidationRules\Tests\TestClasses\Models\TestRouteKeyModel;
+
+class TestRouteKeyModelPolicy
+{
+    use HandlesAuthorization;
+
+    public function edit(User $user, TestRouteKeyModel $testModel): bool
+    {
+        return $testModel->user->id === $user->id;
+    }
+}


### PR DESCRIPTION
This PR adds 2 things, both relating to the `Authorized` rule:

- The ability to specify the auth guard to fetch the user
- When attempting to find the model, it now uses the `resolveRouteBinding` method. This was implemented because I was using a UUID as my attribute name.