### PR TITLE
Implement ISO4217 currency validation rule

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ docs
 vendor
 coverage
 .php_cs.cache
+/.phpunit.result.cache

--- a/README.md
+++ b/README.md
@@ -85,7 +85,9 @@ If you have implemented the `getRouteKeyName` method in your model, it will be u
 
 ### `CountryCode`
 
-Determine if the field under validation is a valid ISO3166 country code.
+Determine if the field under validation is a valid [2 letter ISO3166 country code](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2#Current_codes) (example of valid country codes: `GB`, `DK`, `NL`).
+
+**Note** that this rule require the package [`league/iso3166`](https://github.com/thephpleague/iso3166) to be installed: `composer require league/iso3166`
 
 ```php
 // in a `FormRequest`
@@ -117,7 +119,9 @@ public function rules()
 
 ### `Currency`
 
-Determine if the field under validation is a valid ISO4217 currency.
+Determine if the field under validation is a valid [3 letter ISO4217 currency code](https://en.wikipedia.org/wiki/ISO_4217#Active_codes) (example of valid currencies: `EUR`, `USD`, `CAD`).
+
+**Note** that this rule require the package [`league/iso3166`](https://github.com/thephpleague/iso3166) to be installed: `composer require league/iso3166`
 
 ```php
 // in a `FormRequest`

--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ php artisan vendor:publish --provider="Spatie\ValidationRules\ValidationRulesSer
 
 - [`Authorized`](#authorized)
 - [`CountryCode`](#countrycode)
+- [`Currency`](#currency)
 - [`Enum`](#enum)
 - [`ModelsExist`](#modelsexist)
 - [`Delimited`](#delimited)
@@ -110,6 +111,39 @@ public function rules()
 {
     return [
         'country_code' => [(new CountryCode())->nullable()],
+    ];
+}
+```
+
+### `Currency`
+
+Determine if the field under validation is a valid ISO4217 currency.
+
+```php
+// in a `FormRequest`
+
+use Spatie\ValidationRules\Rules\Currency;
+
+public function rules()
+{
+    return [
+        'currency' => ['required', new Currency()], // Must be present and a valid currency
+    ];
+}
+```
+
+If you want to validate a nullable currency field, simple do not let it be required as described in the [Laravel Docs for implicit validation rules](https://laravel.com/docs/master/validation#implicit-rules):
+> ... when an attribute being validated is not present or contains an empty string, normal validation rules, including custom rules, are not run
+
+```php
+// in a `FormRequest`
+
+use Spatie\ValidationRules\Rules\Currency;
+
+public function rules()
+{
+    return [
+        'currency' => [new Currency()], // This will pass for any valid currency, an empty value or null
     ];
 }
 ```

--- a/composer.json
+++ b/composer.json
@@ -17,11 +17,11 @@
     ],
     "require": {
         "php": "^7.3|^8.0",
-        "alcohol/iso4217": "^4.0",
         "illuminate/support": "^6.0|^7.0|^8.0"
     },
     "require-dev": {
         "laravel/legacy-factories": "^1.0.4",
+        "league/iso3166": "^3.0",
         "myclabs/php-enum": "^1.6",
         "orchestra/testbench": "^4.5|^5.0|^6.0",
         "phpunit/phpunit": "^9.3",

--- a/composer.json
+++ b/composer.json
@@ -17,6 +17,7 @@
     ],
     "require": {
         "php": "^7.3|^8.0",
+        "alcohol/iso4217": "^4.0",
         "illuminate/support": "^6.0|^7.0|^8.0"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -38,7 +38,7 @@
         }
     },
     "suggest": {
-        "league/iso3166": "Needed for the CountryCode rule"
+        "league/iso3166": "Needed for the CountryCode rule and Currency rule"
     },
     "scripts": {
         "test": "vendor/bin/phpunit",

--- a/resources/lang/en/messages.php
+++ b/resources/lang/en/messages.php
@@ -5,6 +5,7 @@ return [
     'enum' => 'This is not a valid value.',
     'model_ids' => 'Some of the given ids do not exist.',
     'country_code' => 'Invalid country code.',
+    'currency' => 'The :attribute must be a valid ISO4217 currency.',
     'delimited' => [
         'unique' => 'You may not specify duplicates.',
         'min' => 'You must specify at least :min :item',

--- a/src/Rules/Currency.php
+++ b/src/Rules/Currency.php
@@ -2,10 +2,8 @@
 
 namespace Spatie\ValidationRules\Rules;
 
-use Alcohol\ISO4217;
-use DomainException;
 use Illuminate\Contracts\Validation\Rule;
-use OutOfBoundsException;
+use League\ISO3166\ISO3166;
 
 class Currency implements Rule
 {
@@ -16,15 +14,13 @@ class Currency implements Rule
     {
         $this->attribute = $attribute;
 
-        if ($value === null) {
+        if ($value === null || $value === '') {
             return false;
         }
 
-        try {
-            return boolval((new ISO4217())->getByAlpha3($value)); // This method does not accept null
-        } catch (DomainException | OutOfBoundsException $exception) {
-            return false;
-        }
+        $currencies = array_unique(data_get((new ISO3166)->all(), '*.currency.*'));
+
+        return in_array($value, $currencies, true);
     }
 
     public function message(): string

--- a/src/Rules/Currency.php
+++ b/src/Rules/Currency.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Spatie\ValidationRules\Rules;
+
+use Alcohol\ISO4217;
+use DomainException;
+use Illuminate\Contracts\Validation\Rule;
+use OutOfBoundsException;
+
+class Currency implements Rule
+{
+    /** @var string */
+    protected $attribute;
+
+    public function passes($attribute, $value): bool
+    {
+        $this->attribute = $attribute;
+
+        if ($value === null) {
+            return false;
+        }
+
+        try {
+            return boolval((new ISO4217())->getByAlpha3($value)); // This method does not accept null
+        } catch (DomainException | OutOfBoundsException $exception) {
+            return false;
+        }
+    }
+
+    public function message(): string
+    {
+        return __('validationRules::messages.currency', [
+            'attribute' => $this->attribute,
+        ]);
+    }
+}

--- a/tests/Rules/CurrencyTest.php
+++ b/tests/Rules/CurrencyTest.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Spatie\ValidationRules\Tests\Rules;
+
+use Spatie\ValidationRules\Rules\Currency;
+use Spatie\ValidationRules\Tests\TestCase;
+
+class CurrencyTest extends TestCase
+{
+    public function test_valid_currency_passes()
+    {
+        $this->assertTrue((new Currency())->passes('currency', 'USD'));
+    }
+
+    public function test_invalid_currency_fails()
+    {
+        $this->assertFalse((new Currency())->passes('currency', 'XYZ'));
+    }
+
+    public function test_null_currency_fails()
+    {
+        $this->assertFalse((new Currency())->passes('currency', null));
+    }
+
+    public function test_empty_currency_fails()
+    {
+        $this->assertFalse((new Currency())->passes('currency', ''));
+    }
+}

--- a/tests/Rules/CurrencyTest.php
+++ b/tests/Rules/CurrencyTest.php
@@ -2,6 +2,7 @@
 
 namespace Spatie\ValidationRules\Tests\Rules;
 
+use Illuminate\Support\Facades\Validator;
 use Spatie\ValidationRules\Rules\Currency;
 use Spatie\ValidationRules\Tests\TestCase;
 
@@ -25,5 +26,77 @@ class CurrencyTest extends TestCase
     public function test_empty_currency_fails()
     {
         $this->assertFalse((new Currency())->passes('currency', ''));
+    }
+
+    public function test_nullable_field()
+    {
+        $this->assertTrue(Validator::make(
+            [
+                'currency' => null,
+            ],
+            [
+                'currency' => ['nullable', new Currency()],
+            ]
+        )->passes());
+
+        $this->assertTrue(Validator::make(
+            [
+                'currency' => null,
+            ],
+            [
+                'currency' => [new Currency()],
+            ]
+        )->fails());
+    }
+
+    public function test_empty_field()
+    {
+        $this->assertTrue(Validator::make(
+            [
+                'currency' => '',
+            ],
+            [
+                'currency' => ['nullable', new Currency()],
+            ]
+        )->passes());
+
+        $this->assertTrue(Validator::make(
+            [
+                'currency' => '',
+            ],
+            [
+                'currency' => [new Currency()],
+            ]
+        )->passes());
+    }
+
+    public function test_required_field()
+    {
+        $this->assertTrue(Validator::make(
+            [
+                'currency' => null,
+            ],
+            [
+                'currency' => ['required', new Currency()],
+            ]
+        )->fails());
+
+        $this->assertTrue(Validator::make(
+            [
+                'currency' => '',
+            ],
+            [
+                'currency' => ['required', new Currency()],
+            ]
+        )->fails());
+
+        $this->assertTrue(Validator::make(
+            [
+                'currency' => 'USD',
+            ],
+            [
+                'currency' => ['required', new Currency()],
+            ]
+        )->passes());
     }
 }


### PR DESCRIPTION
This PR adds a new validation rule for validating [ISO4217 currencies](https://en.wikipedia.org/wiki/ISO_4217) using their most common form which is a three letter code (examples: `USD`, `EUR`, `CNY`).

- [x] Implement validation rule `Currency()`
- [x] Add tests
- [x] Add `README.md` description

This implementation intentionally uses the [alcohol/iso4217](https://github.com/alcohol/iso4217) package for ISO4217 checks (the more downloaded package [Payum/iso4217](https://github.com/Payum/iso4217) is a fork of this one and [has been abandoned](https://github.com/Payum/iso4217/issues/12#issuecomment-757965898)).

Note that an alternative could be to rely on the already required package [thephpleague/iso3166](https://github.com/thephpleague/iso3166) which includes currency codes (see [src/ISO3166.php@L2431](https://github.com/thephpleague/iso3166/blob/b69892c2ad05fcf17f0b4ed4542b535081f36cfa/src/ISO3166.php#L2431)), but I was not able to confirm if this list is in fact complete.