### PR TITLE
use str_getcsv instead of explode in Delimited rule

### DIFF
--- a/src/Rules/Delimited.php
+++ b/src/Rules/Delimited.php
@@ -85,7 +85,7 @@ class Delimited implements Rule
             $value = trim($value);
         }
 
-        $items = collect(explode($this->separatedBy, $value))
+        $items = collect(str_getcsv($value, $this->separatedBy))
             ->filter(function ($item) {
                 return strlen((string) $item) > 0;
             });

--- a/src/Rules/Delimited.php
+++ b/src/Rules/Delimited.php
@@ -25,6 +25,8 @@ class Delimited implements Rule
     /** @var bool */
     protected $trimItems = true;
 
+    protected bool $asCsv = false;
+
     /** @var string */
     protected $validationMessageWord = 'item';
 
@@ -79,13 +81,20 @@ class Delimited implements Rule
         return $this;
     }
 
+    public function asCsv(): static
+    {
+        $this->asCsv = true;
+
+        return $this;
+    }
+
     public function passes($attribute, $value)
     {
         if ($this->trimItems) {
             $value = trim($value);
         }
 
-        $items = collect(str_getcsv($value, $this->separatedBy))
+        $items = collect($this->asCsv ? str_getcsv($value, $this->separatedBy) : explode($this->separatedBy, $value))
             ->filter(function ($item) {
                 return strlen((string) $item) > 0;
             });

--- a/tests/Rules/DelimitedTest.php
+++ b/tests/Rules/DelimitedTest.php
@@ -106,6 +106,15 @@ class DelimitedTest extends TestCase
     }
 
     /** @test */
+    public function it_can_treat_input_as_csv()
+    {
+        $rule = (new Delimited('string|min:5'))->asCsv();
+
+        $this->assertTrue($rule->passes('attribute', '"Doe, John", "Doe, Jane"'));
+        $this->assertFalse($rule->passes('attribute', '"Doe", "Jane"'));
+    }
+
+    /** @test */
     public function it_can_accept_a_rule_as_an_array()
     {
         $rule = new Delimited(['email']);


### PR DESCRIPTION
Using `str_getcsv` to convert the delimited list into an array allows escaping commas inside the list items. 

A real-life example would be list of email address specifications, ie:
`"Doe, John" <johndoe@example.com>, "Doe, Jane" <janedoe@example.com>`.

With the current implementation, the rule will break this into:
```php
[
  ""Doe",
  " John" <johndoe@example.com>",
  ""Doe",
  " Jane" <janedoe@example.com>",
]
```

With `str_getcsv`, we get the expected result:
```php
[
  "Doe, John <johndoe@example.com>",
  "Doe, Jane <janedoe@example.com>",
]
```